### PR TITLE
Update scadcall.sh for v0.2

### DIFF
--- a/voron_nameplates/scadcall.sh
+++ b/voron_nameplates/scadcall.sh
@@ -2,8 +2,10 @@
 
 if [[ $1 == V0* ]] ;
 then	
-openscad -o $2$1"-NoLogo.stl" -D 'serial="'$1'"' -D "logo=false" "/voron_serial_plate/V0/Voron0_Logo_Plate.scad"
-openscad -o $2$1".stl" -D 'serial="'$1'"' "/voron_serial_plate/V0/Voron0_Logo_Plate.scad"
+openscad -o $2$1"v0.2-NoLogo.stl" -D 'serial="'$1'"' -D "logo=false" "/voron_serial_plate/V0/Voron0_Logo_Plate.scad"
+openscad -o $2$1"v0.2.stl" -D 'serial="'$1'"' "/voron_serial_plate/V0/Voron0_Logo_Plate.scad"
+openscad -o $2$1"-NoLogo.stl" -D 'serial="'$1'"' -D "logo=false" -D "zero_dot_two=false" "/voron_serial_plate/V0/Voron0_Logo_Plate.scad"
+openscad -o $2$1".stl" -D 'serial="'$1'"' -D "zero_dot_two=false" "/voron_serial_plate/V0/Voron0_Logo_Plate.scad"
 else
 openscad -o $2$1"-NoLogo.stl" -D 'serial="'$1'"' -D "logo=false" "/voron_serial_plate/Voron_Logo_Plate.scad"
 openscad -o $2$1".stl" -D 'serial="'$1'"' "/voron_serial_plate/Voron_Logo_Plate.scad"


### PR DESCRIPTION
New defaults in the scad will only generate v0.2 serial plates.  This change continues to generate legacy serial plates.

This should be merged in and pushed after https://github.com/rdmullett/voron_serial_plate/pull/5 is merged in.